### PR TITLE
feat: 支持跨层级app join

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -5008,7 +5008,7 @@ public abstract class AbstractSQLConfig implements SQLConfig {
 			alias = j.getAlias();
 			//JOIN子查询不能设置LIMIT，因为ON关系是在子查询后处理的，会导致结果会错误
 			SQLConfig joinConfig = newSQLConfig(method, table, alias, j.getRequest(), null, false, callback);
-			SQLConfig cacheConfig = j.canCacheViceTable() == false ? null : newSQLConfig(method, table, alias, j.getRequest(), null, false, callback).setCount(1);
+			SQLConfig cacheConfig = j.canCacheViceTable() == false ? null : newSQLConfig(method, table, alias, j.getRequest(), null, false, callback).setCount(j.getCount());
 
 			if (j.isAppJoin() == false) { //除了 @ APP JOIN，其它都是 SQL JOIN，则副表要这样配置
 				if (joinConfig.getDatabase() == null) {

--- a/APIJSONORM/src/main/java/apijson/orm/Join.java
+++ b/APIJSONORM/src/main/java/apijson/orm/Join.java
@@ -22,6 +22,7 @@ public class Join {
 	private String joinType;  // "@" - APP, "<" - LEFT, ">" - RIGHT, "*" - CROSS, "&" - INNER, "|" - FULL, "!" - OUTER, "^" - SIDE, "(" - ANTI, ")" - FOREIGN
 	private String table;  // User
 	private String alias;  // owner
+	private int count = 1;	// 当app join子表，需要返回子表的行数，默认1行；
 	private List<On> onList;  // ON User.id = Moment.userId AND ...
 	
 	private JSONObject request;  // { "id@":"/Moment/userId" }
@@ -37,6 +38,13 @@ public class Join {
 	}
 	public void setPath(String path) {
 		this.path = path;
+	}
+
+	public int getCount() {
+		return count;
+	}
+	public void setCount(int count) {
+		this.count = count;
 	}
 
 	public String getJoinType() {


### PR DESCRIPTION
优化app join模式下，一对多join表查询时的1+N性能问题

- 支持客户端join字段，path的多层路径指定
- Join类增加count字段，以支持在生成副表sql时，按照指定count数量生成
- 处理App Join的查询结果时，将'一条条缓存'调整为'攒一起再缓存'，防止错误替换